### PR TITLE
Fix long index names automatically by trimming it as per user consent

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1695,14 +1695,13 @@ module ActiveRecord
         end
 
         def trim_index_name(current_name)
-          max_index_name_length = index_name_length
           new_index_name = current_name.freeze
           indexed_table_names_separator = "_on_"
 
-          while new_index_name.length > max_index_name_length
+          while new_index_name.length > index_name_length
             table_names = new_index_name.split(indexed_table_names_separator)
-            primary_table_name_array = table_names[0].split("_")
-            referenced_table_name_array = table_names[1].split("_")
+            primary_table_name_array = table_names.first.split("_")
+            referenced_table_name_array = table_names.second.split("_")
 
             if primary_table_name_array.length >= referenced_table_name_array.length
               primary_table_name_array.delete_at(1)
@@ -1718,8 +1717,8 @@ module ActiveRecord
           new_index_name
         end
 
-        def validate_and_trim_index_length(table_name, new_name)
-          index_length_error = "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
+        def validate_and_trim_index_length(table_name, index_name)
+          index_length_error = "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
 
           puts("\n#{index_length_error}")
 
@@ -1727,9 +1726,9 @@ module ActiveRecord
 
           user_response = $stdin.getch.chomp
 
-          return new_name if user_response.downcase != "y"
+          return index_name if user_response.downcase != "y"
 
-          trim_index_name(new_name)
+          trim_index_name(index_name)
         end
     end
   end


### PR DESCRIPTION
### Summary

This PR fixes the error of Long Index Name Length before raising the error to the user and aborting migration.

How?

- After automatically generating index name, call a method `validate_and_trim_index_length` to validate the index name and trim it if required
- If the index length is longer than max length configured, ask users if they want to fix the index name automatically by trimming it.
- If the response is "y", trim the index name and return trimmed index name which is set on schema
- If the response if not "y" return the same index name which is long and will throw the ArgumentError saying index name length is longer than 63 chars like what it does at the moment without this fix.
